### PR TITLE
feat(ctx): add one time configuration in root module

### DIFF
--- a/projects/ngx-infi-markdown-showcase/src/app/app.module.ts
+++ b/projects/ngx-infi-markdown-showcase/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
-import { NgxInfiMarkdownModule, NgxInfiMarkdownComponent } from 'projects/ngx-infi-markdown/src/public-api';
+import { NgxInfiMarkdownModule } from 'projects/ngx-infi-markdown/src/public-api';
 
 @NgModule({
   declarations: [AppComponent],

--- a/projects/ngx-infi-markdown/src/lib/_core/configs/index.ts
+++ b/projects/ngx-infi-markdown/src/lib/_core/configs/index.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { UserStyles } from '../models/Style';
+
+export const USER_STYLE_CONFIG = new InjectionToken<UserStyles>('User Style Config');

--- a/projects/ngx-infi-markdown/src/lib/_core/services/tree.service.ts
+++ b/projects/ngx-infi-markdown/src/lib/_core/services/tree.service.ts
@@ -128,6 +128,7 @@ export class TreeService {
   private entityTree: Entity[] = defaultEntities;
   private userStyles: UserStyles;
   private styles: DefaultStyles;
+  private isGlobalConfig: boolean;
 
   constructor() {
     this.listenForStyleChange();
@@ -158,7 +159,15 @@ export class TreeService {
     this.styles = styles;
   }
 
-  setUserStyles(userStyles: UserStyles): void {
+  setUserStyles(userStyles: UserStyles, shouldOverride: boolean): void {
+    if (this.isGlobalConfig) {
+      return;
+    }
+
+    if (shouldOverride) {
+      this.isGlobalConfig = true;
+    }
+
     this.userStyles = userStyles;
   }
 

--- a/projects/ngx-infi-markdown/src/lib/ngx-infi-markdown.component.ts
+++ b/projects/ngx-infi-markdown/src/lib/ngx-infi-markdown.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, ViewEncapsulation, Input } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, Input, Optional, Inject } from '@angular/core';
 import { TreeService } from './_core/services/tree.service';
 import { UserStyles } from './_core/models/Style';
+import { USER_STYLE_CONFIG } from './_core/configs';
 
 @Component({
   selector: 'ngx-infi-markdown',
@@ -29,12 +30,14 @@ import { UserStyles } from './_core/models/Style';
 })
 export class NgxInfiMarkdownComponent implements OnInit {
   @Input() set styles(value: UserStyles) {
-    this.treeService.setUserStyles(value);
+    this.treeService.setUserStyles(value, false);
   }
 
   previewWidth: string;
 
-  constructor(private treeService: TreeService) {}
+  constructor(private treeService: TreeService, @Optional() @Inject(USER_STYLE_CONFIG) config: UserStyles) {
+    config && this.treeService.setUserStyles(config, true);
+  }
 
   ngOnInit(): void {}
 

--- a/projects/ngx-infi-markdown/src/lib/ngx-infi-markdown.module.ts
+++ b/projects/ngx-infi-markdown/src/lib/ngx-infi-markdown.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { NgxInfiMarkdownComponent } from './ngx-infi-markdown.component';
 import { EditorComponent } from './_core/components/editor/editor.component';
 import { PreviewComponent } from './_core/components/preview/preview.component';
@@ -8,6 +8,8 @@ import { SanitizeHtmlPipe } from './_core/pipes/sanitizeHtml.pipe';
 import { MinToolbarComponent } from './_core/components/min-toolbar/min-toolbar.component';
 import { TooltipDirective } from './_core/directives/tooltip.directive';
 import { TooltipComponent } from './_core/components/tooltip/tooltip.component';
+import { UserStyles } from './_core/models/Style';
+import { USER_STYLE_CONFIG } from './_core/configs';
 
 @NgModule({
   declarations: [
@@ -23,4 +25,16 @@ import { TooltipComponent } from './_core/components/tooltip/tooltip.component';
   imports: [CommonModule],
   exports: [NgxInfiMarkdownComponent],
 })
-export class NgxInfiMarkdownModule {}
+export class NgxInfiMarkdownModule {
+  static forRoot(stylesConfig: UserStyles): ModuleWithProviders {
+    return {
+      ngModule: NgxInfiMarkdownModule,
+      providers: [
+        {
+          provide: USER_STYLE_CONFIG,
+          useValue: stylesConfig,
+        },
+      ],
+    };
+  }
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```
I mark this feature as experimental. My motivation is to allow users to create global style configuration for all markdown instances in their application. If a global configuration is not provided, each instance gets its own configuration provided by the parent component or passed by a service. Example:

```
@NgModule({
  declarations: [AppComponent],
  imports: [
    BrowserModule, 
    NgxInfiMarkdownModule.forRoot({
      primaryHeader: {
        ...
      },
      secondaryHeader: {
        ...
      },
      ...
    })
  ],
  providers: [],
  bootstrap: [AppComponent],
})
export class AppModule {}
```